### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Policies or data can be disabled using `--enable-policy=false` or `--enable-data
 
 `kube-mgmt` assumes a `ConfigMap` contains policy or JSON data if the `ConfigMap` is:
 
-- Created in a namespace listed in the `--namespaces` option. If you specify `--namespaces=*` then `kube-mgmt` will look for policies in ALL namespaces.
+- Created in a namespace listed in the `--policies` option. If you specify `--policies=*` then `kube-mgmt` will look for policies in ALL namespaces.
 - Labelled with `openpolicyagent.org/policy=rego` for policies
 - Labelled with `openpolicyagent.org/data=op` for JSON data
 


### PR DESCRIPTION
Container was crashing when --namespaces was used. When going through issues found the below pr, which states that the argument name is --policies. I have tested this change on my system. When using --policies kube-mgmt was able to read opa policies from different namespace other than opa (default namespace).